### PR TITLE
Siri user error handling

### DIFF
--- a/Quest Tracker/CompleteQuestIntent.swift
+++ b/Quest Tracker/CompleteQuestIntent.swift
@@ -23,19 +23,13 @@ struct CompleteQuestIntent: AppIntent {
 
     let context = ModelController.shared.modelContainer.mainContext
 
-    if let foundQuest = Quest.findQuestBy(name: questName, context: context) {
+    if Quest.findActiveQuestBy(name: questName, context: context) != nil {
 
-      if foundQuest.isCompleted {
-        return .result(dialog: "That quest is already marked complete.")
-      } else {
+      Quest.completeQuest(name: questName, context: context)
 
-        Quest.completeQuest(name: questName, context: context)
-
-        return .result(dialog: "\(questName) marked complete.")
-      }
-      
+      return .result(dialog: "\(questName) marked complete.")
     } else {
-      return .result(dialog: "Sorry, I couldn't find a quest called \(questName). Use Add Quest to add it.")
+      return .result(dialog: "Sorry, I couldn't find an active quest called \(questName). Use Add Quest to add it.")
     }
   }
 }

--- a/Quest.swift
+++ b/Quest.swift
@@ -55,8 +55,8 @@ import AppIntents
 
 extension Quest: Identifiable {
 
-  static func findQuestBy(name: String, context: ModelContext) -> Quest? {
-    var request = FetchDescriptor<Quest>(predicate: #Predicate { $0.questName == name })
+  static func findActiveQuestBy(name: String, context: ModelContext) -> Quest? {
+    var request = FetchDescriptor<Quest>(predicate: #Predicate { $0.questName == name && $0.isCompleted == false })
     request.fetchLimit = 1
 
    let foundQuest = try? context.fetch(request).first ?? nil
@@ -65,7 +65,7 @@ extension Quest: Identifiable {
   }
 
   static func completeQuest(name: String, context: ModelContext) {
-    if let quest: Quest = findQuestBy(name: name, context: context) {
+    if let quest: Quest = findActiveQuestBy(name: name, context: context) {
 
       let user: User = User.fetchFirstOrInitialize(context: context)
 


### PR DESCRIPTION
Added user error handling. If a user asks Siri to complete a quest that is not active, Siri informs the user they could not find it and directs the user to use the "add quest" voice command to add the quest.