### PR TITLE
Skip daily or weekly quest

### DIFF
--- a/QuestRowView.swift
+++ b/QuestRowView.swift
@@ -36,26 +36,22 @@ struct QuestRowView: View, Identifiable {
       }
       if quest.isSelected {
         Text(quest.questDescription ?? "")
-        Text("Quest EXP:")
-        HStack {
-          Text("Quest Reward:")
-          Text(quest.questBonusReward ?? "")
+        Text("Quest EXP: \(Int(quest.type.experience))")
+        if quest.questBonusReward != nil {
+          HStack {
+            Text("Quest Reward:")
+            Text(quest.questBonusReward ?? "")
+          }
         }
         if !quest.isCompleted {
-          HStack {
-            NavigationLink(destination: QuestView(
-              quest: quest, hasDueDate: quest.dueDate.exists, settings: settings)) {
-                Button(action: {
-                }, label: {
-                  Text("Edit")
-                }
-                )
+          if quest.type == .weeklyQuest ||
+              quest.type == .dailyQuest {
+              Button {
+                quest.isCompleted = true
+              } label: {
+                Text("Skip Quest")
               }
-            Spacer()
-            Button(action: {
-            },
-                   label: {Text("Complete")})
-          }
+            }
         } else {
           Button {
             restoreQuest(quest: quest)


### PR DESCRIPTION
User can now skip a daily or weekly quest, which adds it to the completedQuests list but does not give exp. These quests will refresh after their corresponding daily or weekly reset.

Removed Edit and Complete buttons from QuestRowView as that functionality is available with swipe actions and the UI looks much cleaner without them.

Made bonusReward line only visible if the quest has a bonus reward.

Made quest experience line show the exp earned by completing the quest.