### PR TITLE
Collapsible sectioned list

### DIFF
--- a/Quest Tracker.xcodeproj/project.pbxproj
+++ b/Quest Tracker.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		8F6462C52B4DE756000DE6A3 /* AddQuestIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6462C42B4DE756000DE6A3 /* AddQuestIntent.swift */; };
 		8F6462C92B506D5F000DE6A3 /* CompleteQuestIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6462C82B506D5F000DE6A3 /* CompleteQuestIntent.swift */; };
 		8F6B15062B2E25AC00784BCE /* AddRewardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6B15052B2E25AC00784BCE /* AddRewardView.swift */; };
+		8F796E892B6C38BA007E0608 /* QuestSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F796E882B6C38BA007E0608 /* QuestSection.swift */; };
+		8F796E8B2B6C40F5007E0608 /* CollapsibleSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F796E8A2B6C40F5007E0608 /* CollapsibleSection.swift */; };
 		8F7F0CD52ABB7FBC007EF1D0 /* QuestTrackerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7F0CD42ABB7FBC007EF1D0 /* QuestTrackerViewModel.swift */; };
 		8F92E9072ABBA58C000446C6 /* QuestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F92E9062ABBA58C000446C6 /* QuestView.swift */; };
 		8FA12A582B27A222005838FE /* ManageRewardsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FA12A572B27A222005838FE /* ManageRewardsView.swift */; };
@@ -44,6 +46,8 @@
 		8F6462C82B506D5F000DE6A3 /* CompleteQuestIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CompleteQuestIntent.swift; path = "Quest Tracker/CompleteQuestIntent.swift"; sourceTree = SOURCE_ROOT; };
 		8F6462CA2B508EA6000DE6A3 /* Quest-Tracker-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Quest-Tracker-Info.plist"; sourceTree = SOURCE_ROOT; };
 		8F6B15052B2E25AC00784BCE /* AddRewardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRewardView.swift; sourceTree = "<group>"; };
+		8F796E882B6C38BA007E0608 /* QuestSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestSection.swift; sourceTree = "<group>"; };
+		8F796E8A2B6C40F5007E0608 /* CollapsibleSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleSection.swift; sourceTree = "<group>"; };
 		8F7F0CD42ABB7FBC007EF1D0 /* QuestTrackerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestTrackerViewModel.swift; sourceTree = "<group>"; };
 		8F92E9062ABBA58C000446C6 /* QuestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestView.swift; sourceTree = SOURCE_ROOT; };
 		8FA12A572B27A222005838FE /* ManageRewardsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageRewardsView.swift; sourceTree = "<group>"; };
@@ -78,6 +82,8 @@
 			children = (
 				8F1EEEDC2B151D750097AB03 /* QuestRowView.swift */,
 				8FD590512B60A07200DF5325 /* QuestList.swift */,
+				8F796E882B6C38BA007E0608 /* QuestSection.swift */,
+				8F796E8A2B6C40F5007E0608 /* CollapsibleSection.swift */,
 				8FC6BFEE2AFABF95001DD91E /* QuestListView.swift */,
 			);
 			path = QuestList;
@@ -265,6 +271,7 @@
 				8F2184502AB8D965004CCF7A /* QuestTrackerModel.swift in Sources */,
 				8FD5904E2B5F151700DF5325 /* Quest.swift in Sources */,
 				8FD590522B60A07200DF5325 /* QuestList.swift in Sources */,
+				8F796E892B6C38BA007E0608 /* QuestSection.swift in Sources */,
 				8F6368572B62F94800D524A1 /* ModelController.swift in Sources */,
 				8F48FD422B1FCDE800A88E96 /* RewardsView.swift in Sources */,
 				8F6462C32B4DE6D6000DE6A3 /* QuestTrackerShortcuts.swift in Sources */,
@@ -273,6 +280,7 @@
 				8FAC38512AB396B6005CBED3 /* Quest_TrackerApp.swift in Sources */,
 				8FD5904D2B5F151700DF5325 /* Settings.swift in Sources */,
 				8FB5D1982B1932DB008EB1F0 /* LevelAndExpUI.swift in Sources */,
+				8F796E8B2B6C40F5007E0608 /* CollapsibleSection.swift in Sources */,
 				8F6462C52B4DE756000DE6A3 /* AddQuestIntent.swift in Sources */,
 				8F92E9072ABBA58C000446C6 /* QuestView.swift in Sources */,
 				8F6B15062B2E25AC00784BCE /* AddRewardView.swift in Sources */,

--- a/Quest Tracker/QuestList/CollapsibleSection.swift
+++ b/Quest Tracker/QuestList/CollapsibleSection.swift
@@ -1,0 +1,50 @@
+//
+//  CollapsibleSection.swift
+//  Quest Tracker
+//
+//  Created by Matt Zawodniak on 2/1/24.
+//
+
+import SwiftUI
+
+class SectionModel: NSObject, ObservableObject {
+
+  @Published var sections: [String: Bool] = [String: Bool]()
+
+  func isOpen(title: String) -> Bool {
+    if let value = sections[title] {
+      return value
+    } else {
+      return true
+    }
+  }
+
+  func toggle(title: String) {
+    let current = sections[title] ?? true
+    withAnimation {
+      sections[title] = !current
+    }
+  }
+}
+
+struct CategoryHeader: View {
+  var title: String
+
+  @ObservedObject var model: SectionModel
+  var number: Int
+
+  var body: some View {
+    HStack {
+      Text(title)
+      if model.isOpen(title: title) == false {
+        Text("(\(number))")
+      }
+      Spacer()
+      Image(systemName: model.isOpen(title: title) ? "chevron.down" : "chevron.up")
+    }
+    .contentShape(Rectangle())
+    .onTapGesture {
+      self.model.toggle(title: self.title)
+    }
+  }
+}

--- a/Quest Tracker/QuestList/QuestListView.swift
+++ b/Quest Tracker/QuestList/QuestListView.swift
@@ -40,13 +40,33 @@ struct QuestListView: View {
 
   let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
+  @ObservedObject private var sections = SectionModel()
+
   var body: some View {
     NavigationStack {
       List {
-        QuestList(sortDescriptor: tracker.sortDescriptorFromSortType(sortType: sortType),
-                  settings: settings,
-                  showingCompletedQuests: showingCompletedQuests,
-                  user: user)
+        if sortType == .questType {
+          ForEach(QuestType.allCases, id: \.self) { type in
+            let title: String = type.description + "s"
+            var numberOfQuestsOfType: Int { filteredQuests.filter({ $0.type == type}).count }
+
+            Section(header: CategoryHeader(title: title, model: self.sections, number: numberOfQuestsOfType)) {
+              if self.sections.isOpen(title: title) {
+                QuestSection(settings: settings,
+                             showingCompletedQuests: showingCompletedQuests,
+                             user: user,
+                             questType: type)
+              } else {
+                EmptyView()
+              }
+            }
+          }
+        } else {
+          QuestList(sortDescriptor: tracker.sortDescriptorFromSortType(sortType: sortType),
+                    settings: settings,
+                    showingCompletedQuests: showingCompletedQuests,
+                    user: user)
+        }
         if !showingCompletedQuests {
           HStack {
             Button(

--- a/Quest Tracker/QuestList/QuestSection.swift
+++ b/Quest Tracker/QuestList/QuestSection.swift
@@ -1,0 +1,69 @@
+//
+//  SortedQuestList.swift
+//  Quest Tracker
+//
+//  Created by Matt Zawodniak on 2/1/24.
+//
+
+import SwiftUI
+import SwiftData
+
+struct QuestSection: View {
+
+    @Environment(\.modelContext) var modelContext
+
+    @Query var quests: [Quest]
+
+    var settings: Settings
+    var showingCompletedQuests: Bool
+    var user: User
+    var questType: QuestType
+
+  init(settings: Settings, showingCompletedQuests: Bool, user: User, questType: QuestType) {
+    _quests = Query(filter: #Predicate { $0.isCompleted == showingCompletedQuests})
+      self.settings = settings
+      self.showingCompletedQuests = showingCompletedQuests
+      self.user = user
+    self.questType = questType
+    }
+
+  var questsOfChosenType: [Quest] {
+    quests.filter({ $0.type == questType }).sorted {$0.questName < $1.questName}
+  }
+
+      var body: some View {
+        ForEach(questsOfChosenType, id: \.self) { (quest: Quest) in
+          QuestRowView(quest: quest, settings: settings)
+          .swipeActions(edge: .trailing) { Button(role: .destructive) {
+            modelContext.delete(quest)
+          } label: {
+            Label("Delete", systemImage: "trash")
+          }
+            if !showingCompletedQuests {
+              NavigationLink(destination: QuestView(
+                quest: quest, hasDueDate: quest.dueDate.exists, settings: settings)) {
+                  Button(action: {
+                  }, label: {
+                    Text("Edit")
+                  }
+                  )
+                }
+            }
+          }
+          .swipeActions(edge: .leading) {
+            if !showingCompletedQuests {
+              Button {
+                quest.isCompleted = true
+                user.giveExp(quest: quest, settings: settings, context: modelContext)
+                quest.timeCompleted = Date.now
+              } label: {
+                Image(systemName: "checkmark")
+              }
+              .tint(.green)          }
+          }
+        }    }
+  }
+  //
+  // #Preview {
+  //    QuestList()
+  // }


### PR DESCRIPTION
When sorted by Type, converts list to sectioned list.
Sections are collapsible.
When collapsed, the number of quests in that section is displayed next to the title of the section.
![Simulator Screenshot - iPhone 15 - 2024-02-01 at 16 41 55](https://github.com/matt-zawodniak/Quest-Tracker/assets/117237030/dab33154-629d-46fa-8820-3fe9b21ccf1a)
![Simulator Screenshot - iPhone 15 - 2024-02-01 at 16 42 03](https://github.com/matt-zawodniak/Quest-Tracker/assets/117237030/7d7639b8-66f0-495a-bf73-c3d6a8c86f8c)
![Simulator Screenshot - iPhone 15 - 2024-02-01 at 16 42 12](https://github.com/matt-zawodniak/Quest-Tracker/assets/117237030/a0ec2add-3384-4548-adbb-fb2f6634e1c7)
![Simulator Screenshot - iPhone 15 - 2024-02-01 at 16 42 23](https://github.com/matt-zawodniak/Quest-Tracker/assets/117237030/496122ba-4a44-40f4-8a91-a2fe5bf5dbc2)

