### PR TITLE
Skip Quest Crash Fix

### DIFF
--- a/QuestRowView.swift
+++ b/QuestRowView.swift
@@ -47,6 +47,7 @@ struct QuestRowView: View, Identifiable {
           if quest.type == .weeklyQuest ||
               quest.type == .dailyQuest {
               Button {
+                quest.timeCompleted = Date()
                 quest.isCompleted = true
               } label: {
                 Text("Skip Quest")


### PR DESCRIPTION
Fixed an issue where app was crashing due to "Skip Quest" button not giving a quest a timeCompleted date, thus causing the reset functions to fail.