### PR TITLE
Lint Line length and interpolated strings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,3 +4,6 @@ identifier_name:
   allowed_symbols: "_"
 excluded:
   - Vendor
+line_length:
+  warning: 150
+  ignores_interpolated_strings: true


### PR DESCRIPTION
Changed SwiftLint to allow lines of length 150.

Changed SwiftLint to ignore interpolated strings for line length warnings.